### PR TITLE
[feat] input system maping 및 버그 픽스

### DIFF
--- a/Assets/Project/Programmer/JHS/PlayerActions.inputactions
+++ b/Assets/Project/Programmer/JHS/PlayerActions.inputactions
@@ -1,0 +1,1105 @@
+{
+    "name": "PlayerActions",
+    "maps": [
+        {
+            "name": "Gameplay",
+            "id": "8f146712-095f-4f39-96c4-e55ffd271ca6",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "a35f4705-a726-4d0d-b506-6f0205ef4709",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "점프",
+                    "type": "Button",
+                    "id": "928b2bf3-b07e-4507-a41e-750fe012fd7e",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "Camera Move",
+                    "type": "Value",
+                    "id": "f2d096e1-e5b1-4835-bd6e-ddad0a9bb049",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "원거리 공격",
+                    "type": "Button",
+                    "id": "cbd15591-aa42-4a43-96f2-e04f9b455d6c",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "특수 공격",
+                    "type": "Button",
+                    "id": "d7c66b5a-2516-4fb4-8587-c6e054dc40b5",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "근접 공격",
+                    "type": "Button",
+                    "id": "aaf867dd-3492-45fb-931a-96e6dea73732",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "락 온",
+                    "type": "Button",
+                    "id": "9b8b8e38-5292-4350-97f6-010494d51a95",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "락 온 취소",
+                    "type": "Button",
+                    "id": "8db66a3b-18d1-403f-b812-243fc81c128b",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "대쉬",
+                    "type": "Button",
+                    "id": "1d6982a7-0ed4-47fb-b6ff-092e5a76fb4a",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "상호작용",
+                    "type": "Button",
+                    "id": "141a8255-f045-4e8f-9cf1-b18c659d07db",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "드레인",
+                    "type": "Button",
+                    "id": "46f09fbf-3c78-4abd-809c-bae08bbf10a7",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "설정 열기",
+                    "type": "Button",
+                    "id": "7b329410-e3de-421f-a2b9-2e94b70f360e",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "가방 열기",
+                    "type": "Button",
+                    "id": "f9d6c28c-afba-409b-805c-c555e06f2569",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "WASD",
+                    "id": "843e9f24-886f-4365-bb12-8097389f1087",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "04bbb22c-71a3-4156-a9e1-4619e7e34b15",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "down",
+                    "id": "64619db3-a1b7-401a-95f2-d7cbdb1e538b",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "left",
+                    "id": "97b0a410-be0f-4349-a351-2a6daf064c36",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "right",
+                    "id": "d9ad487d-ee89-41db-9151-ab2480240d71",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left Stick",
+                    "id": "2c9d7f4e-6b8f-45ba-b3da-a4b137a761e2",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "up",
+                    "id": "9a22cdf9-bcbd-4032-80b3-272a7e2709c9",
+                    "path": "<Gamepad>/leftStick/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Down",
+                    "id": "cfa7f118-4874-47ff-9533-81958b3a9cd8",
+                    "path": "<Gamepad>/leftStick/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left",
+                    "id": "1384c0c0-aebb-4e83-b560-772724237032",
+                    "path": "<Gamepad>/leftStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Right",
+                    "id": "0ce2c370-6d8a-4d43-ab4e-11b0b9630d71",
+                    "path": "<Gamepad>/leftStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Space",
+                    "id": "8741b855-0b69-469e-bc9a-e386ece36cfe",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "점프",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "bcb91619-a32a-4411-893d-b08edd354517",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "점프",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "North",
+                    "id": "8ed29314-43dc-4dae-b506-5d6a76283ac3",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "점프",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "8eb3f4c1-e268-403e-9acb-8454d8954450",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "점프",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Mouse",
+                    "id": "f87e5971-dc64-4bd5-b658-b321fdaed91a",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Camera Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "b60d6d03-3950-4ba5-866f-a35ba95c0637",
+                    "path": "<Mouse>/delta/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Camera Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Negative",
+                    "id": "85f04cfa-2a33-4dff-8c04-44ded34f7bcf",
+                    "path": "<Mouse>/delta/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Camera Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "1D Axis",
+                    "id": "356e86dd-0398-4c28-bfd5-c1c9527e198c",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Camera Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Positive",
+                    "id": "23c89da1-ccda-497b-82d3-9aac4ea86726",
+                    "path": "<Gamepad>/rightStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Camera Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Negative",
+                    "id": "e3d33421-0a3e-493a-9e54-34fb34cc8c3e",
+                    "path": "<Gamepad>/rightStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Camera Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "좌클릭",
+                    "id": "763d01fc-b71e-4d62-91d6-a3b95eb47e85",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "원거리 공격",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "2e8f3693-a90a-42af-ab39-b5cea7c9c9c6",
+                    "path": "<Mouse>/leftButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "원거리 공격",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "3시버튼",
+                    "id": "bf03cef3-ec4f-48d5-a46e-f8c5f64e0c9d",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "원거리 공격",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "d8a8e1c0-72b5-40c2-a368-bf976366f2f5",
+                    "path": "<Gamepad>/buttonEast",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "원거리 공격",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "우클릭",
+                    "id": "8c9c9ce9-6290-4116-9ae1-91582904664c",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "특수 공격",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "de0f264b-e740-4dcf-a90c-38fd086d84bb",
+                    "path": "<Mouse>/rightButton",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "특수 공격",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "12시버튼",
+                    "id": "b2cb4592-a705-4423-8c97-7557c4738243",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "특수 공격",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "5c8e615d-ad36-44bc-bf6a-b033349a7bc0",
+                    "path": "<Gamepad>/buttonNorth",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "특수 공격",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "V Button",
+                    "id": "245b5dba-5121-4a4d-8e91-70f56c0c8f58",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "근접 공격",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "89392261-d409-4176-b60d-0491e22be169",
+                    "path": "<Keyboard>/v",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "근접 공격",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "9시버튼",
+                    "id": "e20e31f8-5fdc-447c-afa0-7988b372d47e",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "근접 공격",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "ceaf3537-b595-40da-8eda-ef2fced775fa",
+                    "path": "<Gamepad>/buttonWest",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "근접 공격",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Tab",
+                    "id": "5f44a670-a692-4f76-a1c6-000ae8a97679",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "락 온",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "414d4d9a-eeeb-4e2a-8c3b-14fe68349ddb",
+                    "path": "<Keyboard>/tab",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "락 온",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "LT",
+                    "id": "22dfe777-e970-4927-ab89-5be586802f0f",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "락 온",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "396c80fc-b478-465a-a1e0-0a5220a63ba6",
+                    "path": "<Gamepad>/leftTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "락 온",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "C Button",
+                    "id": "41d40983-7ec6-4532-bb86-24a314b0ad57",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "락 온 취소",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "202d2dae-78b8-4823-be91-d4c6fa9ff6a2",
+                    "path": "<Keyboard>/c",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "락 온 취소",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "LB",
+                    "id": "75b58c9c-47bf-4c95-bcae-6d7fe8588b20",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "락 온 취소",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "4939b1a1-de58-4d9a-bda1-9148b1f74004",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "락 온 취소",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Shift",
+                    "id": "10862577-d7ad-49f2-89ae-aedd33c3d72c",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "대쉬",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "fac6b7d8-01b0-4bcb-981e-05376ad9485b",
+                    "path": "<Keyboard>/shift",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "대쉬",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "RT",
+                    "id": "01312dbe-daac-48ea-8ed5-ca36e3ab9565",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "대쉬",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "c6265c75-61d0-4f82-a082-46d6868714b1",
+                    "path": "<Gamepad>/rightTrigger",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "대쉬",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "E Button",
+                    "id": "f97c12cd-30e4-4698-b4f0-81d2e09e40a9",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "상호작용",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "d4aed84b-bde3-4a5d-885e-3a9bf281baf9",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "상호작용",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "RB",
+                    "id": "0a19dd4f-20fd-4f34-90a0-968bb96dcef0",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "상호작용",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "e41f55e9-b2d1-44f4-a56a-30557d2f6838",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "상호작용",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Q Button",
+                    "id": "d9ad1de9-cc5c-4afe-b17f-c0b6c3bbc48c",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "드레인",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "2d30f693-4a2a-4913-911e-1dfbf694e044",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "드레인",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "LS",
+                    "id": "6ab6a9c7-551e-4eb1-a4be-ffad371944f6",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "드레인",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "2e2b5e41-ae90-449d-917d-6cb3e4ddad4f",
+                    "path": "<Gamepad>/leftStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "드레인",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "ESC",
+                    "id": "ccc87960-9fd5-4865-b854-42f7bb63f8bf",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "설정 열기",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "c170e127-1f8d-4e53-9351-a563798b04f6",
+                    "path": "<Keyboard>/escape",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "설정 열기",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Start",
+                    "id": "ef781675-bac2-42b7-b3e6-0c92b2226765",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "설정 열기",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "0c71bb92-6d7f-4b28-86bd-a67e6ff8f1d4",
+                    "path": "<Gamepad>/start",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "설정 열기",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "B Button",
+                    "id": "f8bd3d33-31c4-4b6f-8302-908197cfcba5",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "가방 열기",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "c078bed7-653e-4f72-881c-88cee35b1fab",
+                    "path": "<Keyboard>/b",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "가방 열기",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "D-pad Down",
+                    "id": "d75507ae-035d-4799-b2a4-65d7da051edc",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "가방 열기",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "22cc1936-32c1-4bf4-9b5c-8dea104bc817",
+                    "path": "<Gamepad>/dpad/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "가방 열기",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                }
+            ]
+        },
+        {
+            "name": "UI",
+            "id": "fc48f223-ca0c-4628-81f7-c2951d66ac7b",
+            "actions": [
+                {
+                    "name": "Move",
+                    "type": "Value",
+                    "id": "b5c56e30-4f64-4737-a30c-a9138eb054f1",
+                    "expectedControlType": "Vector2",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": true
+                },
+                {
+                    "name": "선택",
+                    "type": "Button",
+                    "id": "21c0a633-bd2b-47ea-b8ec-3e878f16e19e",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "취소",
+                    "type": "Button",
+                    "id": "f7aa4237-ade8-4615-8c39-10aee169058c",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                },
+                {
+                    "name": "분해",
+                    "type": "Button",
+                    "id": "edfc42ac-59fc-4854-a821-01e4e8096670",
+                    "expectedControlType": "",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
+                }
+            ],
+            "bindings": [
+                {
+                    "name": "WASD",
+                    "id": "c678280a-b896-492c-8e9e-0947cb70a51b",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Up",
+                    "id": "a657e340-3452-4101-beac-3d5ef41ff418",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Down",
+                    "id": "5ee85207-d7d5-4784-bf50-4b7d7c0b6855",
+                    "path": "<Keyboard>/s",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left",
+                    "id": "3b558fda-1631-49e3-a661-c528af8df616",
+                    "path": "<Keyboard>/a",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Right",
+                    "id": "59a12838-65fb-4584-a8d3-54e4d118c13c",
+                    "path": "<Keyboard>/d",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left Stick",
+                    "id": "711dd994-eb63-45fc-b2cc-ffff3b60f2d8",
+                    "path": "2DVector",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Move",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "Up",
+                    "id": "e67a417b-c845-4b93-86ad-398a7f7e2411",
+                    "path": "<Gamepad>/leftStick/up",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Down",
+                    "id": "df6934eb-4d60-4299-8c50-f7f6787db4dc",
+                    "path": "<Gamepad>/leftStick/down",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Left",
+                    "id": "85dbcdb1-2324-4ded-a145-31a4c3f3e54d",
+                    "path": "<Gamepad>/leftStick/left",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Right",
+                    "id": "9d8cad06-9cfe-4712-9b86-76381c1b3980",
+                    "path": "<Gamepad>/leftStick/right",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "Move",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "E Button",
+                    "id": "01d165cb-982a-4317-84a1-5fe32bee9494",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "선택",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "59d77b1b-e609-4f30-9780-e836494f0c43",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "선택",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "RB",
+                    "id": "eb1d2e9e-c8ba-473c-bfba-a16a71ff7c69",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "선택",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "ef049fa4-a85d-47a1-a6a9-71ded87c812a",
+                    "path": "<Gamepad>/rightShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "선택",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "Q Button",
+                    "id": "bc4f1a88-2f84-477f-84f7-cfc47009cc7f",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "분해",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "f50ccd6d-9370-4887-a0f0-9f37ce10b0d1",
+                    "path": "<Keyboard>/q",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "분해",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "LS",
+                    "id": "83d12add-c628-49ab-8750-20832cc6c747",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "분해",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "35f8e1a3-bdb8-4d90-8a24-2b0263193d7f",
+                    "path": "<Gamepad>/leftStickPress",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "분해",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "C Button",
+                    "id": "8cc44dcc-cf8e-496f-b82e-57099806c44f",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "취소",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "8a74e259-9dcc-4e57-be15-52973adbf406",
+                    "path": "<Keyboard>/c",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";PC",
+                    "action": "취소",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                },
+                {
+                    "name": "LB",
+                    "id": "6fdfe92e-8f82-4a8f-99a2-ad7ff0146003",
+                    "path": "1DAxis",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "취소",
+                    "isComposite": true,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "positive",
+                    "id": "4ad42dc0-f6b7-476f-9b12-a7633dcd7131",
+                    "path": "<Gamepad>/leftShoulder",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": ";Console",
+                    "action": "취소",
+                    "isComposite": false,
+                    "isPartOfComposite": true
+                }
+            ]
+        }
+    ],
+    "controlSchemes": [
+        {
+            "name": "PC",
+            "bindingGroup": "PC",
+            "devices": [
+                {
+                    "devicePath": "<Mouse>",
+                    "isOptional": false,
+                    "isOR": false
+                },
+                {
+                    "devicePath": "<Keyboard>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        },
+        {
+            "name": "Console",
+            "bindingGroup": "Console",
+            "devices": [
+                {
+                    "devicePath": "<Gamepad>",
+                    "isOptional": false,
+                    "isOR": false
+                }
+            ]
+        }
+    ]
+}

--- a/Assets/Project/Programmer/JHS/PlayerActions.inputactions.meta
+++ b/Assets/Project/Programmer/JHS/PlayerActions.inputactions.meta
@@ -1,0 +1,14 @@
+fileFormatVersion: 2
+guid: e6a6245cdcff6044b88edc5f2f27f0f8
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: 8404be70184654265930450def6a9037, type: 3}
+  generateWrapperCode: 0
+  wrapperCodePath: 
+  wrapperClassName: 
+  wrapperCodeNamespace: 

--- a/Assets/Project/Programmer/JHS/Scripts/OptionSetting.cs
+++ b/Assets/Project/Programmer/JHS/Scripts/OptionSetting.cs
@@ -36,11 +36,6 @@ public class OptionSetting : MonoBehaviour
     private const string MiniMapFixKey = "Option_MiniMapFix";
     private const string LanguageKey = "Option_LanguageKey";
 
-    public void Start()
-    {
-        OptionLoad();
-    }
-
     public void ResetPlayerPrefs()
     {
         PlayerPrefs.DeleteAll();

--- a/Assets/Project/Programmer/JHS/Scripts/SlotManager.cs
+++ b/Assets/Project/Programmer/JHS/Scripts/SlotManager.cs
@@ -19,6 +19,8 @@ public class SlotManager : MonoBehaviour
     private GlobalGameData globalPlayerData;
     [Inject]
     private LobbyUpGrade lobbyUpGrade;
+    [Inject]
+    private GlobalPlayerStateData globalPlayerState;
 
     public GameObject confirmDeleteUI; // 확인 UI
     public Button confirmButton; // 확인 버튼
@@ -71,7 +73,8 @@ public class SlotManager : MonoBehaviour
             userDataManager.nowSlot = slotIndex;  // 슬롯 번호 설정
             userDataManager.LoadData(); // 데이터를 로드하고
             Debug.Log($"Slot {slotIndex + 1} 데이터 불러오기");
-
+            // 플레이어 스탯 초기화
+            globalPlayerState.NewPlayerSetting();
             // 로비 강화 스탯 세팅 (나중에 로딩 창으로 변경)
             lobbyUpGrade.ApplyUpgradeStats();
 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -4,6 +4,7 @@
     "com.unity.collab-proxy": "2.6.0",
     "com.unity.feature.2d": "2.0.1",
     "com.unity.feature.development": "1.0.1",
+    "com.unity.inputsystem": "1.11.2",
     "com.unity.postprocessing": "3.4.0",
     "com.unity.render-pipelines.universal": "14.0.11",
     "com.unity.textmeshpro": "3.0.7",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -198,6 +198,15 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.inputsystem": {
+      "version": "1.11.2",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.modules.uielements": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.mathematics": {
       "version": "1.2.6",
       "depth": 1,


### PR DESCRIPTION
input system 다운
input system maping
게임 종료 후 해당 데이터 슬롯으로 재접속 하면, 공유 강화 효과가 중첩 적용됨  (수정)
이어하기 데이터가 남아있는 상황에서 새로하기 실행 시 이전에 설정한 암유닛이 이전되는 상황 발생 (수정)
게임 시작 시 옵션 불러오기 중첩 적용 수정